### PR TITLE
Build nipkg as part of build pipeline

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -27,3 +27,8 @@ name = 'Engine Libraries'
 type = 'lvBuildSpecAllTargets'
 project = '{cd}'
 build_spec = 'Engine Release'
+
+[package]
+type = 'nipkg'
+payload_dir = 'Built'
+install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices'

--- a/control
+++ b/control
@@ -1,0 +1,14 @@
+Package: ni-engine-simulation-veristand-{veristand_version}-support
+Version: {nipkg_version}
+Architecture: windows_x64
+Maintainer: National Instruments <support@ni.com>
+XB-Plugin: file
+Description: Provides support for the Engine Simulation Toolkit custom device for NI VeriStand {veristand_version}.
+XB-Eula: eula-ni-standard
+Priority: standard
+Homepage: http://www.ni.com
+XB-LanguageSupport: en
+XB-UserVisible: yes
+Section: Add-Ons
+XB-DisplayVersion: {display_version}
+XB-DisplayName: NI Engine Simulation Toolkit for VeriStand {veristand_version}


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-engine-simulation-toolkit-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allows nipkg to be built as part of the Engine Simulation Toolkit custom device pipeline for release branches.

### Why should this Pull Request be merged?

Testing the actual installers we produce and ship is vital. By building the nipkg installer as part of the build process, our automated test system can validate the exact binaries and installers customers will use.

### What testing has been done?

- Verified installer version matches version of release branch and that installer executes and places correct binaries in the correct location
- Successfully added Engine Simulation Toolkit custom device to VeriStand 2018 after installation
