### PR TITLE
Cleanup build output

### DIFF
--- a/Source/Engine Simulation Toolkit Custom Device.lvproj
+++ b/Source/Engine Simulation Toolkit Custom Device.lvproj
@@ -38,6 +38,9 @@
 			</Item>
 		</Item>
 		<Item Name="Utility" Type="Folder">
+			<Item Name="Build Rename" Type="Folder">
+				<Item Name="VariantType.lvlib" Type="Library" URL="/&lt;vilib&gt;/Utility/VariantDataType/VariantType.lvlib"/>
+			</Item>
 			<Item Name="Copy .LLB to NI VeriStand dir.vi" Type="VI" URL="../Utility/Copy .LLB to NI VeriStand dir.vi"/>
 		</Item>
 		<Item Name="Custom Device Engine Simulation Toolkit.xml" Type="Document" URL="../Custom Device Engine Simulation Toolkit.xml"/>
@@ -730,7 +733,6 @@
 				<Item Name="usiPropDef.ctl" Type="VI" URL="/&lt;vilib&gt;/Platform/storage/Storage.llb/usiPropDef.ctl"/>
 				<Item Name="usiTypeDef.ctl" Type="VI" URL="/&lt;vilib&gt;/Platform/storage/Storage.llb/usiTypeDef.ctl"/>
 				<Item Name="Variant to Header Info__ogtk__jki_vi_tester.vi" Type="VI" URL="/&lt;vilib&gt;/addons/_JKI Toolkits/VI Tester/_support/Support.llb/Variant to Header Info__ogtk__jki_vi_tester.vi"/>
-				<Item Name="VariantType.lvlib" Type="Library" URL="/&lt;vilib&gt;/Utility/VariantDataType/VariantType.lvlib"/>
 				<Item Name="VITesterUtilities.lvlib" Type="Library" URL="/&lt;vilib&gt;/addons/_JKI Toolkits/VI Tester/_support/VITesterUtilities.lvlib"/>
 				<Item Name="whitespace.ctl" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/whitespace.ctl"/>
 				<Item Name="LabVIEWHTTPClient.lvlib" Type="Library" URL="/&lt;vilib&gt;/httpClient/LabVIEWHTTPClient.lvlib"/>
@@ -747,6 +749,8 @@
 				<Item Name="UnpackedFlatVectorToMatrix.vi" Type="VI" URL="/&lt;vilib&gt;/NI Veristand/Execution/Shared/UnpackedFlatVectorToMatrix.vi"/>
 				<Item Name="NI_AALBase.lvlib" Type="Library" URL="/&lt;vilib&gt;/Analysis/NI_AALBase.lvlib"/>
 				<Item Name="PackedMatrixToFlatVector.vi" Type="VI" URL="/&lt;vilib&gt;/NI Veristand/Execution/Shared/PackedMatrixToFlatVector.vi"/>
+				<Item Name="LVFixedPointRepBitsTypeDef.ctl" Type="VI" URL="/&lt;vilib&gt;/fxp/LVFixedPointRepBitsTypeDef.ctl"/>
+				<Item Name="LVFixedPointRepRangeTypeDef.ctl" Type="VI" URL="/&lt;vilib&gt;/fxp/LVFixedPointRepRangeTypeDef.ctl"/>
 			</Item>
 			<Item Name="lvStorage.dll" Type="Document" URL="lvStorage.dll">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
@@ -834,7 +838,7 @@
 				<Property Name="DestinationCount" Type="Int">3</Property>
 				<Property Name="Source[0].Container.applyProperties" Type="Bool">true</Property>
 				<Property Name="Source[0].Container.applySaveSettings" Type="Bool">true</Property>
-				<Property Name="Source[0].itemID" Type="Str">{0A075277-EDCB-4668-8FBE-EFAFC78059B3}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{2E32D7E8-AEDB-4F3F-BD50-0EE433E78F9E}</Property>
 				<Property Name="Source[0].properties[0].type" Type="Str">Run when opened</Property>
 				<Property Name="Source[0].properties[0].value" Type="Bool">false</Property>
 				<Property Name="Source[0].properties[1].type" Type="Str">Allow debugging</Property>
@@ -891,7 +895,13 @@
 				<Property Name="Source[5].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[5].itemID" Type="Ref">/My Computer/features.ini</Property>
 				<Property Name="Source[5].sourceInclusion" Type="Str">Include</Property>
-				<Property Name="SourceCount" Type="Int">6</Property>
+				<Property Name="Source[6].itemID" Type="Ref">/My Computer/Utility/Build Rename/VariantType.lvlib/Private/MDTFlavorToTypeEnum.vi</Property>
+				<Property Name="Source[6].newName" Type="Str">_MDTFlavorToTypeEnum.vi</Property>
+				<Property Name="Source[6].type" Type="Str">VI</Property>
+				<Property Name="Source[7].itemID" Type="Ref">/My Computer/Utility/Build Rename/VariantType.lvlib/Private/GetRefnumInfoInternal.vi</Property>
+				<Property Name="Source[7].newName" Type="Str">_GetRefnumInfoInternal.vi</Property>
+				<Property Name="Source[7].type" Type="Str">VI</Property>
+				<Property Name="SourceCount" Type="Int">8</Property>
 			</Item>
 			<Item Name="Engine Debug" Type="Source Distribution">
 				<Property Name="Bld_buildCacheID" Type="Str">{C67C1B30-A649-4BB4-8780-C96741B30EB4}</Property>

--- a/Source/Engine Simulation Toolkit Custom Device.lvproj
+++ b/Source/Engine Simulation Toolkit Custom Device.lvproj
@@ -1016,8 +1016,10 @@
 				<Property Name="Destination[0].type" Type="Str">LLB</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
 				<Property Name="Destination[1].path" Type="Path">../Built/Engine Simulation Toolkit/data</Property>
-				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{08C5CA0D-7DB9-44B5-A9D4-3F9B19F8BA34}</Property>
+				<Property Name="Destination[2].destName" Type="Str">Custom Device Directory</Property>
+				<Property Name="Destination[2].path" Type="Path">../Built/Engine Simulation Toolkit</Property>
+				<Property Name="DestinationCount" Type="Int">3</Property>
+				<Property Name="Source[0].itemID" Type="Str">{D8F23A6E-D2AB-4DAB-BB4D-E1B4A4E104D1}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/Engine Simulation Toolkit Scripting API.lvlib</Property>
@@ -1072,6 +1074,10 @@
 				<Property Name="Source[20].itemID" Type="Ref">/My Computer/Engine Simulation Toolkit Scripting API.lvlib/Custom Device/Set Engine Simulation Toolkit Custom Device.vi</Property>
 				<Property Name="Source[20].type" Type="Str">VI</Property>
 				<Property Name="Source[20].VI.LLBtopLevel" Type="Bool">true</Property>
+				<Property Name="Source[21].destinationIndex" Type="Int">2</Property>
+				<Property Name="Source[21].itemID" Type="Ref">/My Computer/File Formats.lvlibp</Property>
+				<Property Name="Source[21].preventRename" Type="Bool">true</Property>
+				<Property Name="Source[21].sourceInclusion" Type="Str">Include</Property>
 				<Property Name="Source[3].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[3].itemID" Type="Ref">/My Computer/Engine Simulation Toolkit Scripting API.lvlib/Analog Replay/Find Analog Replay.vi</Property>
 				<Property Name="Source[3].type" Type="Str">VI</Property>
@@ -1100,7 +1106,7 @@
 				<Property Name="Source[9].itemID" Type="Ref">/My Computer/Engine Simulation Toolkit Scripting API.lvlib/APU/Get APU.vi</Property>
 				<Property Name="Source[9].type" Type="Str">VI</Property>
 				<Property Name="Source[9].VI.LLBtopLevel" Type="Bool">true</Property>
-				<Property Name="SourceCount" Type="Int">21</Property>
+				<Property Name="SourceCount" Type="Int">22</Property>
 			</Item>
 		</Item>
 	</Item>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-engine-simulation-toolkit-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Make the scripting API build export the File Formats packed library to the same location as the rest of the builds
- Remove name collisions between supported and unsupported variant VIs. These collisions cause two additional directories to be created, which are just clutter. I emailed the last known owner of the GXML library, which uses the unsupported versions, to see what can be done about updating this.

### Why should this Pull Request be merged?

Requested by Dan after some testing.

### What testing has been done?

- Hand testing of the scripting API (via Dan)
- Hand testing of the import/export GXML functionality of the Digital Patterns page.
- Ran automated tests
