### PR TITLE
Clear compile cache before building

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -8,6 +8,10 @@ path = 'Source\Engine Simulation Toolkit Custom Device.lvproj'
 [projects.file_format]
 path = 'Source\File Format Classes\FileFormat.lvproj'
 
+[[codegen.steps]]
+name = 'Clear Compile Cache'
+type = 'lvClearCache'
+
 [[build.steps]]
 name = 'File Format Library'
 type = 'lvBuildSpec'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-engine-simulation-toolkit-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Creates a codegen step to delete the compiled object cache before building this custom device.

### Why should this Pull Request be merged?

There is currently an issue in LabVIEW 2023 where this custom device will build once, but not subsequent times without clearing the compile cache. This change allows us to work around that.

### What testing has been done?

None; copied from https://github.com/ni/niveristand-data-sharing-framework-custom-device/pull/61
